### PR TITLE
new test messages from agrabot are handled

### DIFF
--- a/scripts/bananabot.coffee
+++ b/scripts/bananabot.coffee
@@ -255,10 +255,6 @@ module.exports = (robot) ->
   robot.hear /\((.*?)\) (opened)(.*)(add)(.*)(test)/i, (msg) ->
     user = msg.match[1]
     msg.send "Nice job @#{user} on that new test."
-
-  robot.hear /\((.*?)\) (opened)(.*)(add)(.*)(test)/i, (msg) ->
-    user = msg.match[1]
-    msg.send "Nice job @#{user} on that new test."
     
   robot.hear /(bananatime)/i, (msg) ->
     msg.send "https://media.giphy.com/media/IB9foBA4PVkKA/giphy.gif"

--- a/scripts/bananabot.coffee
+++ b/scripts/bananabot.coffee
@@ -249,8 +249,17 @@ module.exports = (robot) ->
   # Positive Feedback!
   robot.hear /(add)(.*)(test)/i, (msg) ->
     user = msg.message.user.id
-    msg.send "Nice job <@#{user}> on that new test."
+    if user is not 'B94T4HLS1'
+      msg.send "Nice job <@#{user}> on that new test."
 
+  robot.hear /\((.*?)\) (opened)(.*)(add)(.*)(test)/i, (msg) ->
+    user = msg.match[1]
+    msg.send "Nice job @#{user} on that new test."
+
+  robot.hear /\((.*?)\) (opened)(.*)(add)(.*)(test)/i, (msg) ->
+    user = msg.match[1]
+    msg.send "Nice job @#{user} on that new test."
+    
   robot.hear /(bananatime)/i, (msg) ->
     msg.send "https://media.giphy.com/media/IB9foBA4PVkKA/giphy.gif"
 


### PR DESCRIPTION
ArgaBot send message like :"USER_NAME(user_name) opened ticket_numer *Add abc tests* in repo_name: *Add abc tests*" if there is a new MR.
BananaBot get user id and send message: Nice job @B94T4HLS1 on that new test.
BananaBot should get the user name from the message of ArgaBot instead of getting from message sender, and send greetings to @user_name.